### PR TITLE
Fixed offset pins jumping back to zero offset

### DIFF
--- a/js/jquery.superscrollorama.js
+++ b/js/jquery.superscrollorama.js
@@ -141,7 +141,11 @@
 						
 						// unpin it
 						pinObj.state = currScrollPoint < pinObj.pinStart ? 'BEFORE' : 'AFTER';
-						
+						if(pinObj.anim&&pinObj.state === 'BEFORE'){
+							pinObj.anim.progress(0);
+						}else if(pinObj.anim&&pinObj.state === 'AFTER'){
+							pinObj.anim.progress(1);
+						}
 						// revert to original position value
 						el.css('position',pinObj.origPosition);
 						if (superscrollorama.settings.isVertical)


### PR DESCRIPTION
Offset pinned elements were snapping back to an offset (top or left) of 0 once set to position fixed causing them to jump down the page.

Simply setting the top to -offset keeps the pinned element from jumping back to it's start position.

I couldn't think of a use case where the original behaviour would be required but I might be overlooking something.
