### PR TITLE
Callback function for target parameter

### DIFF
--- a/js/jquery.superscrollorama.js
+++ b/js/jquery.superscrollorama.js
@@ -60,6 +60,8 @@
 					offset += offsetAdjust;
 				} else if (typeof(target) === 'number')	{
 					startPoint = target;
+				} else if ($.isFunction(target)) {
+					startPoint = target.call(this);
 				} else {
 					startPoint = superscrollorama.settings.isVertical ? target.offset().top : target.offset().left;
 					offset += offsetAdjust;


### PR DESCRIPTION
Hey John,

Thanks for the super awesome superscrollorama plugin!  It's simple yet powerful, the best kind..

I ran into an issue with a scenario I was dealing with, where I wanted the tween to start at a position relative to statically placed elements.  However, since the target position could change if, say, the browser resized, neither of the existing options for the target parameter would work.  

So I added support for a third type, a callback function.   This function is expected to return the numeric offset value used to trigger the tween.   Simple change, yet even more powerful.  :)

Steve
