### PR TITLE
fixed jQuery undefined error when target is hidden

### DIFF
--- a/js/jquery.superscrollorama.js
+++ b/js/jquery.superscrollorama.js
@@ -96,7 +96,7 @@
 					offset = animObj.offset;
 
 				if (typeof(target) === 'string') {
-                    targetOffset = $(target).offset();
+                    targetOffset = $(target).offset() || {};
 					startPoint = superscrollorama.settings.isVertical ? targetOffset.top + scrollContainerOffset.y : targetOffset.left + scrollContainerOffset.x;
 					offset += offsetAdjust;
 				} else if (typeof(target) === 'number')	{


### PR DESCRIPTION
I was getting the error in the screenshot below in my single page app, when the DOM element attached to superscrollorama was hidden using jQuery. Stepping through the debugger, I isolated the issue. I added an object literal as a default value to account for this case.

![screen shot 2013-07-09 at 12 25 53 pm](https://f.cloud.github.com/assets/3848154/770510/6a5f075c-e8ce-11e2-8f07-567c6c2fb560.png)

The repo where I initially made this change: https://github.com/gdi2290/RedditInsight
