### PR TITLE
Update tweenmax dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,6 @@
   "main": ["js/jquery.superscrollorama.js"],
   "dependencies": {
     "jquery": "~1.9.1",
-    "tweenMax": "latest"
+    "tweenMax": "git@github.com:greensock/GreenSock-JS.git#latest"
   }
 }


### PR DESCRIPTION
It seems that tweenMax was removed from the Bower registry. This renders bower installation impossible. This pull request fixes that problem.
