### PR TITLE
Add `destroy` method

### DIFF
--- a/js/jquery.superscrollorama.js
+++ b/js/jquery.superscrollorama.js
@@ -460,6 +460,15 @@
 			return superscrollorama;
 		};
 
+		superscrollorama.destroy = function() {
+	            	TweenLite.ticker.removeEventListener("tick", tickHandler);
+			for( var i = 0 ; i < animObjects.length ; i++ ) {
+				this.removeTween( animObjects[i].target );
+			}
+			for( var k = 0 ; k < pinnedObjects.length ; k++ ) {
+					this.removePin( pinnedObjects[k].target );
+			}
+		};
 
 		// INIT
 		init();


### PR DESCRIPTION
Removes the added event listener for "tick" and clears all TweenLite animations / pins
